### PR TITLE
Implement Paper.from_url parser

### DIFF
--- a/newsletter/paper.py
+++ b/newsletter/paper.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+from html import unescape
 from typing import List
 
 import urllib.request
@@ -17,12 +18,51 @@ class Paper:
 
     @classmethod
     def from_url(cls, url: str) -> "Paper":
-        """Fetch paper metadata from the given URL and create a Paper.
+        """Fetch paper metadata from the given URL and return a :class:`Paper`.
 
-        This is a stub implementation which performs the GET request but
-        does not yet parse the response.
+        The function downloads the HTML from the arXiv ``abs`` page and
+        extracts information from the ``citation_*`` meta tags which are
+        consistently provided on arXiv pages.  Only a very small subset of
+        fields are parsed (title, authors, abstract and submission date) as
+        required by the :class:`Paper` dataclass.
         """
-        # Perform the request to retrieve the paper metadata
-        urllib.request.urlopen(url)
-        # Parsing of the response is not yet implemented
-        raise NotImplementedError
+
+        # Retrieve the page content.  Tests patch ``urllib.request.urlopen`` so
+        # we stick with ``urllib`` rather than using ``requests``.
+        resp = urllib.request.urlopen(url)
+        html = resp.read().decode("utf-8", errors="ignore")
+
+        # Helper function to extract a single meta tag value using a regular
+        # expression.  The meta tags of interest have the form:
+        #   <meta name="citation_title" content="..." />
+        import re
+
+        def extract(name: str) -> str | None:
+            pattern = rf'<meta[^>]+name=["\']{name}["\'][^>]+content=["\']([^"\']+)["\']'
+            m = re.search(pattern, html, flags=re.IGNORECASE)
+            return unescape(m.group(1)) if m else None
+
+        # Title
+        title = extract("citation_title") or ""
+
+        # Abstract
+        abstract = extract("citation_abstract") or ""
+
+        # Authors can appear multiple times. ``re.findall`` will collect them.
+        authors_pattern = r'<meta[^>]+name=["\']citation_author["\'][^>]+content=["\']([^"\']+)["\']'
+        authors = [unescape(a) for a in re.findall(authors_pattern, html, flags=re.IGNORECASE)]
+
+        # Submission date in format YYYY/MM/DD
+        date_str = extract("citation_date") or "1970/01/01"
+        try:
+            submission_date = date.fromisoformat(date_str.replace("/", "-"))
+        except ValueError:
+            submission_date = date.today()
+
+        return cls(
+            arxiv_url=url,
+            title=title,
+            abstract=abstract,
+            authors=authors,
+            submission_date=submission_date,
+        )

--- a/tests/test_paper.py
+++ b/tests/test_paper.py
@@ -1,11 +1,32 @@
 import os, sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from datetime import date
 from unittest.mock import patch
 
 import pytest
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from newsletter.paper import Paper
+
+
+HTML_PAGE = """\
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="citation_title" content="X-MAS: Towards Building Multi-Agent Systems with Heterogeneous LLMs" />
+<meta name="citation_author" content="Ye, Rui" />
+<meta name="citation_author" content="Liu, Xiangrui" />
+<meta name="citation_author" content="Wu, Qimin" />
+<meta name="citation_author" content="Pang, Xianghe" />
+<meta name="citation_author" content="Yin, Zhenfei" />
+<meta name="citation_author" content="Bai, Lei" />
+<meta name="citation_author" content="Chen, Siheng" />
+<meta name="citation_date" content="2025/05/22" />
+<meta name="citation_abstract" content="LLM-based multi-agent systems (MAS) extend the capabilities of single LLMs by enabling cooperation among multiple specialized agents." />
+</head>
+<body></body>
+</html>
+"""
 
 
 def test_create_paper():
@@ -21,9 +42,24 @@ def test_create_paper():
     assert paper.authors == ["Alice", "Bob"]
 
 
-def test_from_url_uses_get_and_raises_not_implemented():
+def test_from_url_parses_paper_metadata():
     with patch("newsletter.paper.urllib.request.urlopen") as mock_get:
-        mock_get.return_value.read.return_value = b""
-        with pytest.raises(NotImplementedError):
-            Paper.from_url("http://arxiv.org/abs/1234.5678")
+        mock_get.return_value.read.return_value = HTML_PAGE.encode()
+        paper = Paper.from_url("http://arxiv.org/abs/1234.5678")
         mock_get.assert_called_once_with("http://arxiv.org/abs/1234.5678")
+
+    assert paper.title == "X-MAS: Towards Building Multi-Agent Systems with Heterogeneous LLMs"
+    assert paper.authors == [
+        "Ye, Rui",
+        "Liu, Xiangrui",
+        "Wu, Qimin",
+        "Pang, Xianghe",
+        "Yin, Zhenfei",
+        "Bai, Lei",
+        "Chen, Siheng",
+    ]
+    assert paper.abstract == (
+        "LLM-based multi-agent systems (MAS) extend the capabilities of single LLMs by "
+        "enabling cooperation among multiple specialized agents."
+    )
+    assert paper.submission_date == date(2025, 5, 22)


### PR DESCRIPTION
## Summary
- implement `Paper.from_url` to fetch arXiv pages and parse metadata from `citation_*` meta tags
- add tests verifying that `from_url` parses an HTML snippet and returns a populated Paper object

## Testing
- `pytest -q`