### PR TITLE
Add arXiv URL scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # newsletter
+
+Utilities for working with arXiv papers.
+
+## Getting recent cs.AI URLs
+
+```
+from newsletter.arxiv import get_recent_arxiv_urls
+
+urls = get_recent_arxiv_urls()
+print(urls[:5])
+```

--- a/newsletter/arxiv.py
+++ b/newsletter/arxiv.py
@@ -1,0 +1,17 @@
+import re
+from urllib.parse import urljoin
+
+import requests
+
+BASE_URL = "https://arxiv.org"
+RECENT_URL = f"{BASE_URL}/list/cs.AI/recent?skip=0&show=2000"
+
+
+def get_recent_arxiv_urls():
+    """Return a list of arXiv paper URLs from the recent cs.AI page."""
+    response = requests.get(RECENT_URL)
+    response.raise_for_status()
+    pattern = re.compile(r'href="(/abs/[^\"]+)"')
+    matches = pattern.findall(response.text)
+    unique_paths = sorted(set(matches))
+    return [urljoin(BASE_URL, path) for path in unique_paths]

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -1,0 +1,26 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from unittest.mock import Mock, patch
+
+from newsletter.arxiv import get_recent_arxiv_urls, RECENT_URL
+
+
+def test_get_recent_arxiv_urls_parses_links():
+    html = """
+    <html><body>
+    <a href="/abs/1234.5678">paper1</a>
+    <a href="/abs/2345.6789v2">paper2</a>
+    <a href="/notabs/9999">ignore</a>
+    </body></html>
+    """
+    mock_response = Mock()
+    mock_response.text = html
+    mock_response.raise_for_status = Mock()
+
+    with patch('newsletter.arxiv.requests.get', return_value=mock_response) as mock_get:
+        urls = get_recent_arxiv_urls()
+        assert urls == [
+            'https://arxiv.org/abs/1234.5678',
+            'https://arxiv.org/abs/2345.6789v2'
+        ]
+        mock_get.assert_called_once_with(RECENT_URL)


### PR DESCRIPTION
## Summary
- add `get_recent_arxiv_urls` function to fetch cs.AI arXiv URLs
- document usage in README
- test HTML parsing for arXiv URLs

## Testing
- `pytest -q`