### PR TITLE
Add editable installation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ from newsletter.arxiv import get_recent_arxiv_urls
 urls = get_recent_arxiv_urls()
 print(urls[:5])
 ```
+
+## Development
+
+Install the package in editable mode and run the tests:
+
+```bash
+pip install -e .[test]
+pytest -q
+```

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='newsletter',
+    version='0.1.0',
+    packages=find_packages(),
+    install_requires=['requests'],
+)

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -1,5 +1,3 @@
-import os, sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from unittest.mock import Mock, patch
 
 from newsletter.arxiv import get_recent_arxiv_urls, RECENT_URL

--- a/tests/test_paper.py
+++ b/tests/test_paper.py
@@ -1,10 +1,7 @@
-import os, sys
 from datetime import date
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from newsletter.paper import Paper
 


### PR DESCRIPTION
## Summary
- simplify imports in tests by removing manual path modification
- provide `setup.py` for editable installs
- document editable installs and running tests

## Testing
- `pip install -e . --no-build-isolation --no-deps --no-use-pep517`
- `pytest -q`