### PR TITLE
Add combined search score and sorting

### DIFF
--- a/tests/test_fetch_recent_papers.py
+++ b/tests/test_fetch_recent_papers.py
@@ -1,0 +1,40 @@
+import asyncio
+import json
+from datetime import date
+from unittest.mock import patch
+
+import fetch_recent_papers
+from newsletter.paper import Paper
+
+
+def test_main_sorts_by_score(tmp_path):
+    out = tmp_path / "out.jsonl"
+
+    p1 = Paper(
+        arxiv_url="u1",
+        title="p1",
+        abstract="",
+        authors=[],
+        submission_date=date(2023, 1, 1),
+    )
+    p2 = Paper(
+        arxiv_url="u2",
+        title="p2",
+        abstract="",
+        authors=[],
+        submission_date=date(2023, 1, 1),
+    )
+    p1.twitter_results = ["t1", "t2"]
+    p1.google_results = ["g1"]
+    p2.twitter_results = ["t1"]
+    p2.google_results = ["g1", "g2", "g3"]
+
+    with patch.object(fetch_recent_papers, "OUTPUT_FILE", str(out)), \
+         patch.object(fetch_recent_papers, "get_recent_arxiv_urls", return_value=["u1", "u2"]), \
+         patch("fetch_recent_papers.Paper.from_url", side_effect=[p1, p2]):
+        asyncio.run(fetch_recent_papers.main())
+
+    lines = out.read_text().splitlines()
+    assert len(lines) == 2
+    first = json.loads(lines[0])
+    assert first["arxiv_url"] == "u2"

--- a/tests/test_paper.py
+++ b/tests/test_paper.py
@@ -171,3 +171,34 @@ def test_query_google_and_twitter_and_counts():
     counts = paper.search_result_counts()
     assert counts == {"twitter": 2, "google": 2}
 
+
+def test_compute_combined_scores():
+    p1 = Paper(
+        arxiv_url="u1",
+        title="p1",
+        abstract="",
+        authors=[],
+        submission_date=date(2023, 1, 1),
+    )
+    p2 = Paper(
+        arxiv_url="u2",
+        title="p2",
+        abstract="",
+        authors=[],
+        submission_date=date(2023, 1, 1),
+    )
+    p1.twitter_results = ["t1", "t2"]
+    p1.google_results = ["g1"]
+    p2.twitter_results = ["t1"]
+    p2.google_results = ["g1", "g2", "g3"]
+
+    Paper.compute_scores([p1, p2])
+
+    mean_twitter = (2 + 1) / 2
+    mean_google = (1 + 3) / 2
+    expected_p1 = (2 / mean_twitter) + (1 / mean_google)
+    expected_p2 = (1 / mean_twitter) + (3 / mean_google)
+
+    assert pytest.approx(p1.combined_score) == expected_p1
+    assert pytest.approx(p2.combined_score) == expected_p2
+


### PR DESCRIPTION
## Summary
- track a `combined_score` for each `Paper`
- compute score from Twitter and Google results normalized by the mean
- update fetch script to sort papers by the new score and output ISO dates
- test score calculations and script ordering

## Testing
- `pytest -q`