### PR TITLE
Refactor newsletter package

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,22 @@ urls = get_recent_arxiv_urls()
 print(urls[:5])
 ```
 
+## Downloading recent papers
+
+The script :mod:`fetch_recent_papers` downloads the latest cs.AI papers,
+computes simple search scores and writes the results to ``papers.jsonl``:
+
+```bash
+python fetch_recent_papers.py
+```
+
 ## Development
 
 Install the package in editable mode and run the tests:
 
 ```bash
 pip install -e .[test]
+black -q .
 pytest -q
 ```
 ## License

--- a/fetch_recent_papers.py
+++ b/fetch_recent_papers.py
@@ -10,23 +10,38 @@ from newsletter.paper import Paper
 
 OUTPUT_FILE = "papers.jsonl"
 
+
+def _serialize_paper(paper: Paper) -> dict:
+    """Return a JSON-serialisable representation of ``paper``."""
+
+    data = asdict(paper)
+    if isinstance(data.get("submission_date"), date):
+        data["submission_date"] = data["submission_date"].isoformat()
+    return data
+
+
 async def fetch_paper(url: str) -> Paper:
     """Fetch a single paper concurrently."""
     return await asyncio.to_thread(Paper.from_url, url)
 
-async def main() -> None:
+
+async def main(output_file: str | None = None) -> None:
+    """Download recent papers and write them to ``output_file``."""
+
+    if output_file is None:
+        output_file = OUTPUT_FILE
+
     urls = get_recent_arxiv_urls()
     tasks = [fetch_paper(url) for url in urls]
     papers = await asyncio.gather(*tasks)
     Paper.compute_scores(papers)
     papers.sort(key=lambda p: p.combined_score, reverse=True)
-    with open(OUTPUT_FILE, "w", encoding="utf-8") as fh:
+
+    with open(output_file, "w", encoding="utf-8") as fh:
         for paper in papers:
-            data = asdict(paper)
-            if isinstance(data.get("submission_date"), date):
-                data["submission_date"] = data["submission_date"].isoformat()
-            json.dump(data, fh)
+            json.dump(_serialize_paper(paper), fh)
             fh.write("\n")
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/newsletter/__init__.py
+++ b/newsletter/__init__.py
@@ -1,0 +1,6 @@
+"""Public package API for :mod:`newsletter`."""
+
+from .arxiv import get_recent_arxiv_urls
+from .paper import Paper
+
+__all__ = ["get_recent_arxiv_urls", "Paper"]

--- a/newsletter/arxiv.py
+++ b/newsletter/arxiv.py
@@ -11,13 +11,13 @@ import requests
 
 BASE_URL = "https://arxiv.org"
 RECENT_URL = f"{BASE_URL}/list/cs.AI/recent?skip=0&show=2000"
+ABS_LINK_RE = re.compile(r'href="(/abs/[^\"]+)"')
 
 
 def get_recent_arxiv_urls() -> list[str]:
-    """Return a list of arXiv paper URLs from the recent cs.AI page."""
-    response = requests.get(RECENT_URL)
+    """Return a sorted list of unique arXiv paper URLs from the cs.AI listing."""
+    response = requests.get(RECENT_URL, timeout=10)
     response.raise_for_status()
-    pattern = re.compile(r'href="(/abs/[^\"]+)"')
-    matches = pattern.findall(response.text)
+    matches = ABS_LINK_RE.findall(response.text)
     unique_paths = sorted(set(matches))
     return [urljoin(BASE_URL, path) for path in unique_paths]

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='newsletter',
-    version='0.1.0',
+    name="newsletter",
+    version="0.1.0",
     packages=find_packages(),
-    install_requires=['requests'],
+    install_requires=["requests"],
 )

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -15,13 +15,13 @@ def test_get_recent_arxiv_urls_parses_links():
     mock_response.text = html
     mock_response.raise_for_status = Mock()
 
-    with patch('newsletter.arxiv.requests.get', return_value=mock_response) as mock_get:
+    with patch("newsletter.arxiv.requests.get", return_value=mock_response) as mock_get:
         urls = get_recent_arxiv_urls()
         assert urls == [
-            'https://arxiv.org/abs/1234.5678',
-            'https://arxiv.org/abs/2345.6789v2'
+            "https://arxiv.org/abs/1234.5678",
+            "https://arxiv.org/abs/2345.6789v2",
         ]
-        mock_get.assert_called_once_with(RECENT_URL)
+        mock_get.assert_called_once_with(RECENT_URL, timeout=10)
 
 
 def test_get_recent_arxiv_urls_dedup_and_sort():
@@ -36,9 +36,9 @@ def test_get_recent_arxiv_urls_dedup_and_sort():
     mock_response.text = html
     mock_response.raise_for_status = Mock()
 
-    with patch('newsletter.arxiv.requests.get', return_value=mock_response):
+    with patch("newsletter.arxiv.requests.get", return_value=mock_response):
         urls = get_recent_arxiv_urls()
         assert urls == [
-            'https://arxiv.org/abs/1234.5678',
-            'https://arxiv.org/abs/3456.7890v2',
+            "https://arxiv.org/abs/1234.5678",
+            "https://arxiv.org/abs/3456.7890v2",
         ]

--- a/tests/test_fetch_recent_papers.py
+++ b/tests/test_fetch_recent_papers.py
@@ -33,15 +33,16 @@ def test_main_sorts_by_score(tmp_path):
     p2.twitter_results = ["t1"]
     p2.google_results = ["g1", "g2", "g3"]
 
-    with patch.object(fetch_recent_papers, "OUTPUT_FILE", str(out)), \
-         patch.object(fetch_recent_papers, "get_recent_arxiv_urls", return_value=["u1", "u2"]), \
-         patch("fetch_recent_papers.Paper.from_url", side_effect=[p1, p2]):
+    with patch.object(fetch_recent_papers, "OUTPUT_FILE", str(out)), patch.object(
+        fetch_recent_papers, "get_recent_arxiv_urls", return_value=["u1", "u2"]
+    ), patch("fetch_recent_papers.Paper.from_url", side_effect=[p1, p2]):
         asyncio.run(fetch_recent_papers.main())
 
     lines = out.read_text().splitlines()
     assert len(lines) == 2
     first = json.loads(lines[0])
     assert first["arxiv_url"] == "u2"
+
 
 def test_fetch_paper_calls_from_url():
     sample = Paper(
@@ -73,7 +74,8 @@ def test_main_writes_jsonl(tmp_path: Path):
     ) as mock_urls, patch(
         "fetch_recent_papers.Paper.from_url", return_value=sample
     ) as mock_from, patch(
-        "fetch_recent_papers.asdict", lambda p: {
+        "fetch_recent_papers.asdict",
+        lambda p: {
             "arxiv_url": p.arxiv_url,
             "title": p.title,
             "abstract": p.abstract,
@@ -81,7 +83,7 @@ def test_main_writes_jsonl(tmp_path: Path):
             "submission_date": p.submission_date.isoformat(),
             "twitter_results": p.twitter_results,
             "google_results": p.google_results,
-        }
+        },
     ):
         asyncio.run(fetch_recent_papers.main())
 


### PR DESCRIPTION
## Summary
- refactor Paper.from_url to use requests
- expose main functions in __init__
- add utilities for serializing papers and writing output
- modernize arxiv utilities
- document fetch_recent_papers usage
- format codebase with black

## Testing
- `pytest -q`