### PR TITLE
Improve arXiv fetch reliability

### DIFF
--- a/newsletter/arxiv.py
+++ b/newsletter/arxiv.py
@@ -11,12 +11,16 @@ import requests
 
 BASE_URL = "https://arxiv.org"
 RECENT_URL = f"{BASE_URL}/list/cs.AI/recent?skip=0&show=2000"
-ABS_LINK_RE = re.compile(r'href="(/abs/[^\"]+)"')
+# Accept both single and double quoted href attributes
+ABS_LINK_RE = re.compile(r"href=['\"](/abs/[^'\"]+)['\"]")
+
+# User agent to avoid being blocked by arXiv when running outside tests
+HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; newsletter/1.0)"}
 
 
 def get_recent_arxiv_urls() -> list[str]:
     """Return a sorted list of unique arXiv paper URLs from the cs.AI listing."""
-    response = requests.get(RECENT_URL, timeout=10)
+    response = requests.get(RECENT_URL, timeout=10, headers=HEADERS)
     response.raise_for_status()
     matches = ABS_LINK_RE.findall(response.text)
     unique_paths = sorted(set(matches))

--- a/tests/test_arxiv.py
+++ b/tests/test_arxiv.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock, patch
 
-from newsletter.arxiv import get_recent_arxiv_urls, RECENT_URL
+from newsletter.arxiv import get_recent_arxiv_urls, RECENT_URL, HEADERS
 
 
 def test_get_recent_arxiv_urls_parses_links():
@@ -21,7 +21,7 @@ def test_get_recent_arxiv_urls_parses_links():
             "https://arxiv.org/abs/1234.5678",
             "https://arxiv.org/abs/2345.6789v2",
         ]
-        mock_get.assert_called_once_with(RECENT_URL, timeout=10)
+        mock_get.assert_called_once_with(RECENT_URL, timeout=10, headers=HEADERS)
 
 
 def test_get_recent_arxiv_urls_dedup_and_sort():


### PR DESCRIPTION
## Summary
- make the link regex more robust and add a User-Agent when requesting the listing page
- update tests for the new request signature

## Testing
- `pytest -q`