### PR TITLE
Add logging to fetching utilities

### DIFF
--- a/newsletter/arxiv.py
+++ b/newsletter/arxiv.py
@@ -5,6 +5,7 @@ fully-qualified URLs of papers appearing on the recent cs.AI listing page.
 """
 
 import re
+import logging
 from urllib.parse import urljoin
 
 import requests
@@ -17,11 +18,21 @@ ABS_LINK_RE = re.compile(r"href=['\"](/abs/[^'\"]+)['\"]")
 # User agent to avoid being blocked by arXiv when running outside tests
 HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; newsletter/1.0)"}
 
+logger = logging.getLogger(__name__)
+
 
 def get_recent_arxiv_urls() -> list[str]:
     """Return a sorted list of unique arXiv paper URLs from the cs.AI listing."""
+
+    logger.info("Requesting %s", RECENT_URL)
     response = requests.get(RECENT_URL, timeout=10, headers=HEADERS)
     response.raise_for_status()
+    logger.debug(
+        "Received response (status %s) with %d characters",
+        getattr(response, "status_code", "unknown"),
+        len(response.text),
+    )
     matches = ABS_LINK_RE.findall(response.text)
     unique_paths = sorted(set(matches))
+    logger.info("Found %d unique URLs", len(unique_paths))
     return [urljoin(BASE_URL, path) for path in unique_paths]


### PR DESCRIPTION
## Summary
- add logger for fetch_recent_papers and log counts as pages are fetched
- log requests and matches when reading arXiv listing
- log fetch/parsing steps for each Paper

## Testing
- `pytest -q`