### PR TITLE
Refactor utilities into shared module

### DIFF
--- a/fetch_recent_papers.py
+++ b/fetch_recent_papers.py
@@ -4,31 +4,15 @@ import asyncio
 import json
 import logging
 from dataclasses import asdict
-from datetime import date
 
 from newsletter.arxiv import get_recent_arxiv_urls
 from newsletter.paper import Paper
+from newsletter.utils import serialize_paper
 
 logger = logging.getLogger(__name__)
 
 OUTPUT_FILE = "papers.jsonl"
 
-
-def _serialize_paper(paper: Paper) -> dict:
-    """Return a JSON-serialisable representation of ``paper``."""
-
-    data = asdict(paper)
-    if isinstance(data.get("submission_date"), date):
-        data["submission_date"] = data["submission_date"].isoformat()
-    return data
-
-
-async def fetch_paper(url: str) -> Paper:
-    """Fetch a single paper concurrently."""
-    logger.debug("Fetching paper %s", url)
-    paper = await asyncio.to_thread(Paper.from_url, url)
-    logger.debug("Finished fetching %s", url)
-    return paper
 
 
 async def fetch_paper(
@@ -66,7 +50,7 @@ async def main(
 
     with open(output_file, "w", encoding="utf-8") as fh:
         for paper in papers:
-            json.dump(_serialize_paper(paper), fh)
+            json.dump(serialize_paper(paper, asdict_fn=asdict), fh)
             fh.write("\n")
 
 

--- a/newsletter/paper.py
+++ b/newsletter/paper.py
@@ -11,17 +11,7 @@ import logging
 import requests
 from bs4 import BeautifulSoup
 
-
-def _extract_meta(soup: BeautifulSoup, name: str) -> str | None:
-    """Return the content of a ``citation_*`` meta tag if present."""
-
-    tag = soup.find("meta", attrs={"name": name})
-    if tag and tag.has_attr("content"):
-        content = unescape(tag["content"])
-        logger.debug("Extracted %s: %s", name, content)
-        return content
-    logger.debug("Meta tag %s not found", name)
-    return None
+from .utils import extract_meta
 
 
 from googlesearch import search as google_search
@@ -84,11 +74,11 @@ class Paper:
         )
 
         # Title
-        title = _extract_meta(soup, "citation_title") or ""
+        title = extract_meta(soup, "citation_title") or ""
         logger.debug("Parsed title: %s", title)
 
         # Abstract
-        abstract = _extract_meta(soup, "citation_abstract") or ""
+        abstract = extract_meta(soup, "citation_abstract") or ""
 
         # Authors can appear multiple times.
         authors = [
@@ -99,7 +89,7 @@ class Paper:
         logger.debug("Parsed %d authors", len(authors))
 
         # Submission date in format YYYY/MM/DD
-        date_str = _extract_meta(soup, "citation_date") or "1970/01/01"
+        date_str = extract_meta(soup, "citation_date") or "1970/01/01"
         try:
             submission_date = date.fromisoformat(date_str.replace("/", "-"))
         except ValueError:

--- a/newsletter/utils.py
+++ b/newsletter/utils.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from datetime import date
+from html import unescape
+from typing import TYPE_CHECKING, Callable
+
+from bs4 import BeautifulSoup
+
+if TYPE_CHECKING:
+    from .paper import Paper
+
+logger = logging.getLogger(__name__)
+
+
+def extract_meta(soup: BeautifulSoup, name: str) -> str | None:
+    """Return the content of a ``citation_*`` meta tag if present."""
+
+    tag = soup.find("meta", attrs={"name": name})
+    if tag and tag.has_attr("content"):
+        content = unescape(tag["content"])
+        logger.debug("Extracted %s: %s", name, content)
+        return content
+    logger.debug("Meta tag %s not found", name)
+    return None
+
+
+def serialize_paper(paper: "Paper", *, asdict_fn: Callable = asdict) -> dict:
+    """Return a JSON-serialisable representation of ``paper``."""
+
+    data = asdict_fn(paper)
+    if isinstance(data.get("submission_date"), date):
+        data["submission_date"] = data["submission_date"].isoformat()
+    return data


### PR DESCRIPTION
## Summary
- move meta tag parsing and paper serialization to new `newsletter.utils`
- remove unused duplicate function in `fetch_recent_papers`
- use shared helpers for fetching logic

## Testing
- `pytest -q`